### PR TITLE
Split user and group groups interface.

### DIFF
--- a/Products/membrane/interfaces/__init__.py
+++ b/Products/membrane/interfaces/__init__.py
@@ -19,6 +19,7 @@ from Products.membrane.interfaces.plugins import IMembraneUserFactoryPlugin  # n
 
 from Products.membrane.interfaces.group import IGroup  # noqa
 from Products.membrane.interfaces.group import IMembraneGroupProperties  # noqa
+from Products.membrane.interfaces.group import IMembraneGroupGroups  # noqa
 
 from Products.membrane.at.interfaces import IUserAuthProvider
 from Products.membrane.at.interfaces import IUserAuthentication

--- a/Products/membrane/interfaces/configure.zcml
+++ b/Products/membrane/interfaces/configure.zcml
@@ -11,6 +11,10 @@
       type=".membrane_tool.IMembraneQueryableInterface" />
 
     <interface
+      interface=".group.IMembraneGroupGroups"
+      type=".membrane_tool.IMembraneQueryableInterface" />
+
+    <interface
       interface=".user.IMembraneUserObject"
       type=".membrane_tool.IMembraneQueryableInterface" />
 

--- a/Products/membrane/interfaces/group.py
+++ b/Products/membrane/interfaces/group.py
@@ -3,6 +3,7 @@ Group interface
 """
 
 from Products.PlonePAS.interfaces.plugins import IMutablePropertiesPlugin
+from Products.PluggableAuthService.interfaces.plugins import IGroupsPlugin
 from zope.interface import Interface
 
 
@@ -32,4 +33,11 @@ class IGroup(Interface):
 class IMembraneGroupProperties(IGroup, IMutablePropertiesPlugin):
     """
     Used for objects that can provide group properties.
+    """
+
+
+class IMembraneGroupGroups(IGroup, IGroupsPlugin):
+    """
+    Used for objects that can provide group groups.
+    So: groups that belong to groups.
     """

--- a/changes.rst
+++ b/changes.rst
@@ -4,13 +4,29 @@ Changelog
 3.0 (unreleased)
 ----------------
 
+Breaking changes:
+
+- Split user and group groups interface.  A group that implemented
+  ``user.IUserGroupsProvider`` would get included when listing
+  members, which led to ``AttributeError: 'NoneType' object has no
+  attribute '__of__'``.  The new interface is
+  ``group.IGroupGroupsProvider``.  We look for this in our group
+  manager plugin in the ``getGroupsForPrincipal`` method.  If no
+  providers are found, we try the old way for backwards compatibility.
+  [maurits]
+
 - Split user properties and group properties interface.  A group that
   implemented IPropertiesProvider would get included when listing
   members, which led to ``AttributeError: 'NoneType' object has no
   attribute '__of__'``.  Renamed ``IPropertiesProvider`` to
   ``IUserPropertiesProvider`` but kept the old name as alias for
   backwards compatibility.  Added ``IGroupPropertiesProvider``.
+  You may need to reindex the ``membrane_tool`` catalog if you have problems.
   [maurits]
+
+- Dropped compatibility with Plone 4.2 and lower.  [maurits]
+
+New features:
 
 - Fixed tests on Plone 5.  Added Travis for continuous integration
   testing on Plone 4.3 and 5.0.  We only test with Python 2.7.
@@ -18,9 +34,9 @@ Changelog
 
 - Ported tests to plone.app.testing.  [maurits]
 
-- Fixed various pep8 and pyflakes errors and warnings.  [maurits]
+Bug fixes:
 
-- Dropped compatibility with Plone 4.2 and lower.  [maurits]
+- Fixed various pep8 and pyflakes errors and warnings.  [maurits]
 
 
 2.1.13 (2015-11-05)


### PR DESCRIPTION
A group that implemented ``user.IUserGroupsProvider`` would get included when listing members, which led to ``AttributeError: 'NoneType' object has no attribute '__of__'``.  The new interface is ``group.IGroupGroupsProvider``.  We look for this in our groupmanager plugin in the ``getGroupsForPrincipal`` method.  If no providers are found, we try the old way for backwards compatibility.

(Note: discovered in Quaive / Plone Intranet.)