### PR TITLE
Fix user/group search for @@sharing

### DIFF
--- a/Products/membrane/plugins/groupmanager.py
+++ b/Products/membrane/plugins/groupmanager.py
@@ -127,10 +127,10 @@ class MembraneGroupManager(BasePlugin, Cacheable):
         group_info = []
         plugin_id = self.getId()
 
-        if isinstance(id, str):
+        if isinstance(id, basestring):
             id = [id]
 
-        if isinstance(title, str):
+        if isinstance(title, basestring):
             title = [title]
 
         mbtool = getToolByName(self, TOOLNAME)

--- a/Products/membrane/plugins/usermanager.py
+++ b/Products/membrane/plugins/usermanager.py
@@ -99,10 +99,10 @@ class MembraneUserManager(BasePlugin, Cacheable):
         plugin_id = self.getId()
         view_name = createViewName('enumerateUsers', id or login)
 
-        if isinstance(id, str):
+        if isinstance(id, basestring):
             id = [id]
 
-        if isinstance(login, str) and login:
+        if isinstance(login, basestring) and login:
             login = [login]
 
         mbtool = getToolByName(self, TOOLNAME)


### PR DESCRIPTION
A while ago (https://github.com/plone/plone.app.workflow/commit/24d47b45e8a80b670796d35e9b07dd3c5780bcf4) the sharing view was changed to pass unicode as search_term to its various "hunters" for users and groups instead of string.

Over some hops, a search for a user / group for assigning new Roles on the sharing tab can land in the enumerateUsers/Groups methods of membrane. The search parameters are checked if they are a `str`, and if yes, they are converted to a list. Later, the search query is built by iterating over this list (unless an exact match is requested).

Since the search term is now unicode, the conversion to list does not happen, and the search term is broken apart letter by letter for the `getGroupId` search.

Checking for `basestring` instead fixed this issue.

