### PR TITLE
Provide email property in `enumerateUsers` to enable username recovery.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
   Added support for Python 3.11.
   [ale-rt]
 
+- Provide `email` property in `enumerateUsers` if possible.
+  This is needed for `@@login-help` to recover the username of a member.
+  [petschki]
+
 
 6.0.0 (2022-10-10)
 ------------------

--- a/Products/membrane/plugins/usermanager.py
+++ b/Products/membrane/plugins/usermanager.py
@@ -201,6 +201,7 @@ class MembraneUserManager(BasePlugin, Cacheable):
                 login=member.getUserName(),
                 pluginid=plugin_id,
                 editurl="%s/edit" % obj.absolute_url(),
+                email=getattr(member.context, "email", None),
             )
             user_info.append(info)
 


### PR DESCRIPTION
Plone's `@@login-help` view provides a username recovery functionality which searches for users by email. This fixes enumerating membrane users via `IUserEnumerationPlugin` provider by return the email property in the memberinfo.